### PR TITLE
Fix a race condition in docker-compose.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ services:
     volumes:
       - /mnt/docker/mysql/db:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin -u $$MYSQL_USER -p$$MYSQL_PASSWORD ping -h localhost || exit 1"]
+      test: ["CMD-SHELL", "mysql -u $$MYSQL_USER -p$$MYSQL_PASSWORD -e 'SELECT 1;'"]
       start_period: 10s
       interval: 2s
       timeout: 5s

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ services:
     ports:
       - 80:8888
     depends_on:
-      - mariadb
+      mariadb:
+        condition: service_healthy
 
   mariadb:
     image: mariadb:10.5
@@ -104,6 +105,12 @@ services:
       - MYSQL_PASSWORD=xxxxxxxxxx
     volumes:
       - /mnt/docker/mysql/db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin -u $$MYSQL_USER -p$$MYSQL_PASSWORD ping -h localhost || exit 1"]
+      start_period: 10s
+      interval: 2s
+      timeout: 5s
+      retries: 20
 ```
 
 #### 3 - Run it


### PR DESCRIPTION
This fixes a race condition between mariadb and Flarium. This race condition happens the FIRST time a container is started. Mariadb will not be ready when Flarium tries to access it. This causes the installer to fail.